### PR TITLE
64bit環境でうまく動作しないへの対応

### DIFF
--- a/dialog.hpp
+++ b/dialog.hpp
@@ -51,7 +51,7 @@ struct DialogTemplate {
 	static inline void Alignment(BYTE* &p, SizeT &c, SizeT al) {
 		c += al; // 大きい分には問題ないのでサイズ計算用にはアライン分を足す
 		if (p) {
-			ULONG n = al-1;
+			ULONGLONG n = al-1;
 			p = (BYTE*) ((intptr_t)(p + n) & ~n);
 		}
 	}

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,11 @@
 #ifdef _MSC_VER
 #define ISOLATION_AWARE_ENABLED 1
 #pragma comment(lib, "comctl32.lib")
+#ifdef _WIN64
+#pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='amd64' publicKeyToken='6595b64144ccf1df' language='*'\"")
+#else
 #pragma comment(linker,"/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")
+#endif
 #endif
 
 #include "ncbind.hpp"


### PR DESCRIPTION
64bit対応でうまく動かない問題への対応として以下の修正を行いました。
これで、k2compatによるコンソール表示までは成功しました。
・アライメントを32bitで切り捨てている問題の修正
・マニフェストが64bit対応していなかった問題の修正